### PR TITLE
Set junit_family to xunit2

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+junit_family = xunit2
 markers =
     selenium: tests using selenium to do browser tests


### PR DESCRIPTION
This will be the default in pytest 6 and is the modern way.