### PR TITLE
Add Linux Client tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ To see all markers:
 ```
 pytest --markers
 ```
+
+## Launching Linux clients
+
+The client tests will automatically run on any local running podman containers. They can be launched using
+
+```
+podman run --rm --detach --label smoker-linux-client --name centos-7 centos:7 /sbin/init
+podman run --rm --detach --label smoker-linux-client --name centos-8 centos:8 /sbin/init
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest-base-url
 pytest-selenium
+pytest-testinfra
 pytest-variables
 pytest-xdist

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,0 +1,29 @@
+import pytest
+import testinfra
+
+
+def pytest_generate_tests(metafunc):
+    if 'linux_client' in metafunc.fixturenames:
+        host = testinfra.get_host('local://')
+        containers = host.podman.get_containers(label='smoker-linux-client', status='running')
+        linux_clients = [f"podman://{container.id}" for container in containers]
+        ids = [container.name for container in containers]
+
+        metafunc.parametrize('linux_client', linux_clients, ids=ids, indirect=True)
+
+
+@pytest.fixture(scope="module")
+def linux_client(request):
+    host = testinfra.get_host(request.param)
+
+    subman = host.package("subscription-manager")
+    if not subman.is_installed:
+        print('Installing subscription-manager')
+        host.run('yum -y install subscription-manager')
+
+    return host
+
+
+def test_subman_installed(linux_client):
+    subman = linux_client.package("subscription-manager")
+    assert subman.is_installed


### PR DESCRIPTION
This is a very basic version, but shows some general concepts. The goal is to allow discussion on how to replace the bats tests.