### PR TITLE
Add client testing via containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,4 +22,4 @@ jobs:
           pip install flake8
       - name: Run flake8
         run: |
-          flake8 --ignore=E402,W503 --max-line-length=160 tests/
+          flake8 --ignore=E402,W503 --max-line-length=180 tests/

--- a/README.md
+++ b/README.md
@@ -73,3 +73,21 @@ To see all markers:
 ```
 pytest --markers
 ```
+
+## Client Tests
+
+The client tests require the input set of containers to exist prior to running. All the required images can be built based on the version of Foreman being tested:
+
+```
+./build_images.sh <version>
+```
+
+The set of clients to test must also be specified in `variables.json`:
+
+```
+  "clients": [
+    "smoker-test/centos8:nightly",
+    "smoker-test/centos7:nightly",
+    "smoker-test/centos6:nightly"
+  ]
+```

--- a/build_images.sh
+++ b/build_images.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+foreman_version=$1
+
+if [[ -z $foreman_version ]] ; then
+  echo "Usage: $0 FOREMAN_VERSION"
+  exit 1
+fi
+
+podman build images/centos8 -t smoker-test/centos8:$foreman_version --build-arg foreman_version=$foreman_version
+podman build images/centos7 -t smoker-test/centos7:$foreman_version --build-arg foreman_version=$foreman_version
+podman build images/centos6 -t smoker-test/centos6:$foreman_version --build-arg foreman_version=$foreman_version

--- a/images/centos6/Dockerfile
+++ b/images/centos6/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.centos.org/centos:6
+
+ARG foreman_version
+
+RUN rm -f /etc/yum.repos.d/*
+ADD centos-6-vault.repo /etc/yum.repos.d/centos-6-vault.repo
+ADD epel-subscription-manager.repo /etc/yum.repos.d/epel-subscription-manager.repo
+RUN yum -y install https://archives.fedoraproject.org/pub/archive/epel/6/x86_64/epel-release-6-8.noarch.rpm
+RUN yum -y install http://yum.theforeman.org/client/$foreman_version/el6/x86_64/foreman-client-release.rpm
+
+RUN yum -y clean all && yum -y install upstart subscription-manager
+
+CMD /sbin/init

--- a/images/centos6/centos-6-vault.repo
+++ b/images/centos6/centos-6-vault.repo
@@ -1,0 +1,13 @@
+[C6-base]
+name=CentOS-6 - Base
+baseurl=http://vault.centos.org/centos/6/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1
+
+[C6-updates]
+name=CentOS-6 - Updates
+baseurl=http://vault.centos.org/centos/6/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=1

--- a/images/centos6/epel-subscription-manager.repo
+++ b/images/centos6/epel-subscription-manager.repo
@@ -1,0 +1,16 @@
+# Place this file in your /etc/yum.repos.d/ directory
+
+[epel-subscription-manager]
+name=Tools and libraries for Red Hat subscription management.
+baseurl=http://repos.fedorapeople.org/repos/candlepin/subscription-manager/epel-$releasever/$basearch/
+enabled=1
+skip_if_unavailable=1
+gpgcheck=0
+
+[epel-subscription-manager-source]
+name=Tools and libraries for Red Hat subscription management. - Source
+baseurl=http://repos.fedorapeople.org/repos/candlepin/subscription-manager/epel-$releasever/SRPMS
+enabled=0
+skip_if_unavailable=1
+gpgcheck=0
+

--- a/images/centos7/Dockerfile
+++ b/images/centos7/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.centos.org/centos:7
+
+ARG foreman_version
+
+RUN yum -y install http://yum.theforeman.org/client/$foreman_version/el7/x86_64/foreman-client-release.rpm
+
+RUN yum -y install subscription-manager
+
+CMD /sbin/init

--- a/images/centos8/Dockerfile
+++ b/images/centos8/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.centos.org/centos:8
+
+ARG foreman_version
+
+RUN yum -y install http://yum.theforeman.org/client/$foreman_version/el8/x86_64/foreman-client-release.rpm
+
+RUN yum -y install subscription-manager
+
+CMD /sbin/init

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,6 @@ junit_family = xunit2
 sensitive_url = None
 markers =
     selenium: tests using selenium to do browser tests
+    containers: tests container tooling against Katello content
+    katello_agent: tests of katello-agent functionality
 selenium_capture_debug = always

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ apypie
 pytest-base-url
 pytest-html
 pytest-selenium
+pytest-testinfra
 pytest-variables
 pytest-xdist

--- a/tests/test_content_client.py
+++ b/tests/test_content_client.py
@@ -1,0 +1,167 @@
+import pytest
+import testinfra
+import time
+import subprocess
+
+
+@pytest.fixture
+def katello_client(request, entities, registration_hostname):
+    image_id = subprocess.check_output(['podman', 'images', '-q', '--filter', f"reference={request.param}"])
+    assert image_id
+
+    container_id = subprocess.check_output([
+        'podman',
+        'run',
+        '--volume',
+        '/dev/log:/dev/log',
+        '--detach',
+        '--tty',
+        request.param
+    ]).decode().strip()
+
+    try:
+        container = testinfra.get_host("podman://" + container_id)
+
+        container.run_expect([0], f"rpm -Uvh http://{registration_hostname}/pub/katello-ca-consumer-latest.noarch.rpm")
+        container.run_expect([0], f"subscription-manager register --force --org={entities['organization_label']} --activationkey=\"{entities['activation_key']}\"")
+
+        consumed = container.check_output("subscription-manager list --consumed")
+        assert entities['product'] in consumed
+
+        # return a testinfra connection to the container
+        yield container
+
+    finally:
+        subprocess.check_call(['podman', 'rm', '-f', container_id])
+
+
+@pytest.fixture
+def katello_agent_client(katello_client):
+    katello_client.run_expect([0], 'yum -y install katello-agent')
+
+    katello_agent = katello_client.package('katello-agent')
+    assert katello_agent.is_installed
+
+    return katello_client
+
+
+@pytest.fixture
+def os_release_major(katello_client):
+    return katello_client.system_info.release.split('.')[0]
+
+
+def wait_for_task(task, api):
+    duration = 60
+    poll = 15
+
+    while task['state'] not in ['paused', 'stopped']:
+        duration -= poll
+        if duration <= 0:
+            break
+        time.sleep(poll)
+
+        task = api.resource('foreman_tasks').call('show', {'id': task['id']})
+
+
+def foreman_host(client, api):
+    hostname = client.check_output('hostname -s')
+    return api.resource('hosts').call('show', {'id': hostname})
+
+
+def test_register_with_subscription_manager(katello_client, entities, api, user):
+    command = f"subscription-manager register --force --org={entities['organization_label']} --username={user.username} --password={user.password} --env=Library"
+    katello_client.run_expect([0], command)
+
+    assert foreman_host(katello_client, api)
+
+
+def test_enable_content_view_repo(katello_client, entities):
+    enable = katello_client.check_output(
+        f"subscription-manager repos --enable={entities['organization_label']}_{entities['product_label']}_{entities['yum_repository_label']}"
+    )
+
+    assert "is enabled for this system" in enable
+
+
+def test_install_katello_host_tools(katello_client):
+    katello_client.run_expect([0], 'yum -y install katello-host-tools')
+    katello_host_tools = katello_client.package('katello-host-tools')
+    assert katello_host_tools.is_installed
+
+
+def test_install_package_local(katello_client):
+    katello_client.run('yum -y install walrus-0.71')
+    walrus = katello_client.package('walrus')
+
+    assert walrus.is_installed
+    assert walrus.version == '0.71'
+
+
+def test_available_errata(katello_client, entities, api, os_release_major):
+    if os_release_major == "6":
+        katello_client.run_expect([0], 'yum -y install katello-host-tools')
+
+    katello_client.run('yum -y install walrus-0.71')
+
+    host = foreman_host(katello_client, api)
+    errata = api.resource('errata').call('index', {'host_id': host['id']})
+    errata_ids = [erratum['errata_id'] for erratum in errata['results']]
+
+    assert entities['errata_id'] in errata_ids
+
+
+@pytest.mark.katello_agent
+def test_katello_agent_package_install(katello_agent_client, api):
+    host = foreman_host(katello_agent_client, api)
+    task = api.resource('host_packages').call('install', {'host_id': host['id'], 'packages': ['gorilla']})
+    wait_for_task(task, api)
+
+    gorilla = katello_agent_client.package('gorilla')
+    assert gorilla.is_installed
+
+
+@pytest.mark.katello_agent
+def test_katello_agent_errata_install(katello_agent_client, entities, api):
+    katello_agent_client.run('yum -y install walrus-0.71')
+    host = foreman_host(katello_agent_client, api)
+    task = api.resource('host_errata').call('apply', {
+        'host_id': host['id'],
+        'errata_ids': [entities['errata_id']],
+        'included': {},
+        'excluded': {}
+    })
+    wait_for_task(task, api)
+
+    walrus = katello_agent_client.package('walrus')
+    assert walrus.is_installed
+    assert walrus.version == '5.21'
+
+
+@pytest.mark.katello_agent
+def test_katello_agent_remove_package(katello_agent_client, api):
+    host = foreman_host(katello_agent_client, api)
+
+    katello_agent_client.run_expect([0], 'yum -y install gorilla')
+    gorilla = katello_agent_client.package('gorilla')
+    assert gorilla.is_installed
+
+    task = api.resource('host_packages').call('remove', {'host_id': host['id'], 'packages': ['gorilla']})
+    wait_for_task(task, api)
+    gorilla = katello_agent_client.package('gorilla')
+    assert not gorilla.is_installed
+
+
+@pytest.mark.containers
+def test_fetch_container_content(katello_client, entities, registration_hostname, os_release_major, user):
+    if os_release_major == "6":
+        pytest.skip("container content not supported on EL6")
+
+    container_label = f"{entities['organization_label']}-{entities['product_label']}-{entities['container_repository_label']}".lower()
+    docker_connection = f"docker://{registration_hostname}/{container_label}"
+
+    katello_client.run('yum -y install skopeo')
+    katello_client.run('mkdir containers')
+    katello_client.run_expect([0], f"curl -O http://{registration_hostname}/pub/katello-server-ca.crt")
+    katello_client.run_expect([1], f"skopeo copy {docker_connection} dir:containers --src-creds doesnotexist:changeme --src-cert-dir .")
+    katello_client.run_expect([0], f"skopeo copy {docker_connection} dir:containers --src-creds {user.username}:{user.password} --src-cert-dir .")
+    katello_client.run_expect([1], f"skopeo copy docker://{registration_hostname}/{container_label} dir:containers --src-cert-dir .")

--- a/variables.json.example
+++ b/variables.json.example
@@ -1,0 +1,9 @@
+{
+  "username": "admin",
+  "password": "changeme",
+  "clients": [
+    "smoker-test/centos8:nightly",
+    "smoker-test/centos7:nightly",
+    "smoker-test/centos6:nightly"
+  ]
+}


### PR DESCRIPTION
Adds client testing by spinning up containers defined in `variables.json` based on `foreman_version`, `clients` and `hostname` of the server. This design currently relies on the idea that there is a dedicated box that runs smoker that can install hammer on it and run at least podman.

Design considerations:
 * Using apypie instead of hammer to be able to more all in one style testing
 * Relies on the tests living all in a single module and is order dependent
 * Handles creating and destroying requested containers to allow for easy re-running of tests and single, pytest driven command to do so