### PR TITLE
don't run in timeouts on nightly that has no account_menu anymore

### DIFF
--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -9,6 +9,7 @@ import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import TimeoutException
 
 
 @pytest.fixture
@@ -50,10 +51,16 @@ def test_menu_item(selenium, user, url):
     password_field.send_keys(user.password)
     password_field.submit()
 
-    account_menu = WebDriverWait(selenium, 10).until(
-        EC.presence_of_element_located((By.ID, 'account_menu'))
-    )
-    assert account_menu.text == user.name, 'Logged in user shows the correct name'
+    # Foreman 2.5 changed the navigation
+    try:
+        account_menu = WebDriverWait(selenium, 10).until(
+            EC.presence_of_element_located((By.CLASS_NAME, 'user-nav-item'))
+        )
+    except TimeoutException:
+        account_menu = WebDriverWait(selenium, 10).until(
+            EC.presence_of_element_located((By.ID, 'account_menu'))
+        )
+    assert account_menu.get_attribute('textContent') == user.name, 'Logged in user shows the correct name'
 
     expected_parsed_url = urlparse(url)
     allowed_query_params = parse_qs(expected_parsed_url.query).keys()


### PR DESCRIPTION
this does explicitly not assert the username, as for some reason
webdriver says .text is empty and I didn't dig deeper

at least we know we're logged in as some user