### PR TITLE
pin pytest-variables to < 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pytest-base-url
 pytest-html
 pytest-selenium
 pytest-testinfra
-pytest-variables
+pytest-variables<3
 pytest-xdist


### PR DESCRIPTION
pytest-variables 3+ changed how the vars are stored inside, breaking our use of config._variables to access them raw