### PR TITLE
Make browser log level threshold configurable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,10 @@ from urllib.parse import urlparse
 User = namedtuple('User', ['username', 'password', 'name'])
 
 
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'internal: mark test as a self test')
+
+
 def pytest_generate_tests(metafunc):
     variables = metafunc.config._variables  # pylint: disable=protected-access
 


### PR DESCRIPTION
Previously it was tuned to only trigger on SEVERE messages, but the desire is to make it stricter and also fail tests when there are warnings. By making it a variable, it can be changed without changing the code.

I haven't tested this yet, other than introducing some self-testing logic.