### PR TITLE
exclude table_prerences errors from being blocking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -20,6 +20,8 @@ BrowserLogLevel = IntFlag('BrowserLogLevel', ['ALL', 'DEBUG', 'INFO', 'WARNING',
 EXCLUDE_ERRORS = (
     # Fixed in Foreman 3.7 - https://projects.theforeman.org/issues/36093
     'Scrollbar test exception: TypeError:',
+    # New hosts page wants to load table_preferences, but those might not exist
+    'table_preferences/hosts'
 )
 
 


### PR DESCRIPTION
New hosts page wants to load table_preferences, but those might not exist (if the user didn't create any), and the API rightfully returns a 404.
It would be nice if we could supress that 404, but for now let's just ignore the error.